### PR TITLE
feat: add GetCDSView, GetBehaviorDefinition, GetServiceDefinition, RunSQL tools

### DIFF
--- a/src/handlers/handleGetBehaviorDefinition.ts
+++ b/src/handlers/handleGetBehaviorDefinition.ts
@@ -1,0 +1,16 @@
+import { McpError, ErrorCode } from '../lib/utils';
+import { makeAdtRequest, return_error, return_response, getBaseUrl } from '../lib/utils';
+
+export async function handleGetBehaviorDefinition(args: any) {
+    try {
+        if (!args?.bdef_name) {
+            throw new McpError(ErrorCode.InvalidParams, 'Behavior Definition name is required');
+        }
+        const encodedName = encodeURIComponent(args.bdef_name.toUpperCase());
+        const url = `${await getBaseUrl()}/sap/bc/adt/ddic/bdef/sources/${encodedName}/source/main`;
+        const response = await makeAdtRequest(url, 'GET', 30000);
+        return return_response(response);
+    } catch (error) {
+        return return_error(error);
+    }
+}

--- a/src/handlers/handleGetCDSView.ts
+++ b/src/handlers/handleGetCDSView.ts
@@ -1,0 +1,16 @@
+import { McpError, ErrorCode } from '../lib/utils';
+import { makeAdtRequest, return_error, return_response, getBaseUrl } from '../lib/utils';
+
+export async function handleGetCDSView(args: any) {
+    try {
+        if (!args?.view_name) {
+            throw new McpError(ErrorCode.InvalidParams, 'CDS View name is required');
+        }
+        const encodedName = encodeURIComponent(args.view_name.toUpperCase());
+        const url = `${await getBaseUrl()}/sap/bc/adt/ddic/ddl/sources/${encodedName}/source/main`;
+        const response = await makeAdtRequest(url, 'GET', 30000);
+        return return_response(response);
+    } catch (error) {
+        return return_error(error);
+    }
+}

--- a/src/handlers/handleGetServiceDefinition.ts
+++ b/src/handlers/handleGetServiceDefinition.ts
@@ -1,0 +1,16 @@
+import { McpError, ErrorCode } from '../lib/utils';
+import { makeAdtRequest, return_error, return_response, getBaseUrl } from '../lib/utils';
+
+export async function handleGetServiceDefinition(args: any) {
+    try {
+        if (!args?.srvd_name) {
+            throw new McpError(ErrorCode.InvalidParams, 'Service Definition name is required');
+        }
+        const encodedName = encodeURIComponent(args.srvd_name.toUpperCase());
+        const url = `${await getBaseUrl()}/sap/bc/adt/ddic/srvd/sources/${encodedName}/source/main`;
+        const response = await makeAdtRequest(url, 'GET', 30000);
+        return return_response(response);
+    } catch (error) {
+        return return_error(error);
+    }
+}

--- a/src/handlers/handleRunSQL.ts
+++ b/src/handlers/handleRunSQL.ts
@@ -1,16 +1,14 @@
 import { McpError, ErrorCode } from '../lib/utils';
 import { createAxiosInstance, getAuthHeaders, return_error, getBaseUrl } from '../lib/utils';
 
-export async function handleGetTableContents(args: any) {
+export async function handleRunSQL(args: any) {
     try {
-        if (!args?.table_name) {
-            throw new McpError(ErrorCode.InvalidParams, 'Table name is required');
+        if (!args?.sql_query) {
+            throw new McpError(ErrorCode.InvalidParams, 'sql_query is required');
         }
         const maxRows = args.max_rows || 100;
-        const tableName = args.table_name.toUpperCase();
         const baseUrl = await getBaseUrl();
         const url = `${baseUrl}/sap/bc/adt/datapreview/freestyle?rowNumber=${maxRows}&sap-client=100`;
-        const sql = `SELECT * FROM ${tableName}`;
 
         const response = await createAxiosInstance()({
             method: 'POST',
@@ -20,7 +18,7 @@ export async function handleGetTableContents(args: any) {
                 'Content-Type': 'text/plain',
                 'Accept': 'application/xml, text/plain, */*'
             },
-            data: sql,
+            data: args.sql_query,
             timeout: 30000
         });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,10 @@ import { handleGetTypeInfo } from './handlers/handleGetTypeInfo';
 import { handleGetInterface } from './handlers/handleGetInterface';
 import { handleGetTransaction } from './handlers/handleGetTransaction';
 import { handleSearchObject } from './handlers/handleSearchObject';
+import { handleGetCDSView } from './handlers/handleGetCDSView';
+import { handleGetBehaviorDefinition } from './handlers/handleGetBehaviorDefinition';
+import { handleGetServiceDefinition } from './handlers/handleGetServiceDefinition';
+import { handleRunSQL } from './handlers/handleRunSQL';
 
 // Import shared utility functions and types
 import { getBaseUrl, getAuthHeaders, createAxiosInstance, makeAdtRequest, return_error, return_response } from './lib/utils';
@@ -284,6 +288,48 @@ export class mcp_abap_adt_server {
             }
           },
           {
+            name: 'GetCDSView',
+            description: 'Retrieve CDS View (DDL source) source code',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                view_name: {
+                  type: 'string',
+                  description: 'Name of the CDS View (e.g. ZI_MY_VIEW)'
+                }
+              },
+              required: ['view_name']
+            }
+          },
+          {
+            name: 'GetBehaviorDefinition',
+            description: 'Retrieve RAP Behavior Definition (BDEF) source code',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                bdef_name: {
+                  type: 'string',
+                  description: 'Name of the Behavior Definition (e.g. ZI_MY_BDEF)'
+                }
+              },
+              required: ['bdef_name']
+            }
+          },
+          {
+            name: 'GetServiceDefinition',
+            description: 'Retrieve RAP Service Definition (SRVD) source code',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                srvd_name: {
+                  type: 'string',
+                  description: 'Name of the Service Definition (e.g. ZUI_MY_SERVICE)'
+                }
+              },
+              required: ['srvd_name']
+            }
+          },
+          {
             name: 'GetInterface',
             description: 'Retrieve ABAP interface source code',
             inputSchema: {
@@ -295,6 +341,25 @@ export class mcp_abap_adt_server {
                 }
               },
               required: ['interface_name']
+            }
+          },
+          {
+            name: 'RunSQL',
+            description: 'Execute an Open SQL SELECT query against the SAP system via ADT data preview (read-only). Use standard Open SQL syntax, e.g. SELECT * FROM T007L WHERE LAND1 = \'BE\'',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                sql_query: {
+                  type: 'string',
+                  description: 'Open SQL SELECT statement'
+                },
+                max_rows: {
+                  type: 'number',
+                  description: 'Maximum number of rows to return (default 100)',
+                  default: 100
+                }
+              },
+              required: ['sql_query']
             }
           }
         ]
@@ -330,6 +395,14 @@ export class mcp_abap_adt_server {
           return await handleGetInterface(request.params.arguments);
         case 'GetTransaction':
           return await handleGetTransaction(request.params.arguments);
+        case 'GetCDSView':
+          return await handleGetCDSView(request.params.arguments);
+        case 'GetBehaviorDefinition':
+          return await handleGetBehaviorDefinition(request.params.arguments);
+        case 'GetServiceDefinition':
+          return await handleGetServiceDefinition(request.params.arguments);
+        case 'RunSQL':
+          return await handleRunSQL(request.params.arguments);
         default:
           throw new McpError(
             ErrorCode.MethodNotFound,


### PR DESCRIPTION
## Summary

- **GetCDSView**: reads CDS View DDL source via `/sap/bc/adt/ddic/ddl/sources/{name}/source/main`
- **GetBehaviorDefinition**: reads RAP Behavior Definition (BDEF) via `/sap/bc/adt/ddic/bdef/sources/{name}/source/main`
- **GetServiceDefinition**: reads RAP Service Definition (SRVD) via `/sap/bc/adt/ddic/srvd/sources/{name}/source/main`
- **RunSQL**: executes a read-only Open SQL SELECT via the standard ADT data preview endpoint `/sap/bc/adt/datapreview/freestyle`
- **Fix GetTableContents**: replaces the broken custom Z-service endpoint with the standard ADT data preview endpoint — works on any S/4HANA system without custom developments

## Details

The previous `GetTableContents` implementation called `/z_mcp_abap_adt/z_tablecontent/` which requires a custom ABAP service not present in most systems. The new implementation uses the standard ADT freestyle data preview endpoint (`POST /sap/bc/adt/datapreview/freestyle`) which is available on any SAP system with ADT enabled.

The new `RunSQL` tool accepts any Open SQL SELECT statement with filters, making it possible to query configuration tables like T007K, T007L, FOT_ATR_COUNTRY etc. directly from the MCP client.

## Test plan

- [ ] `GetCDSView` with a known CDS view name (e.g. `I_CompanyCode`)
- [ ] `GetBehaviorDefinition` with a RAP BDEF name
- [ ] `GetServiceDefinition` with a SRVD name
- [ ] `RunSQL` with `SELECT * FROM T000` to verify data preview works
- [ ] `GetTableContents` with any table (e.g. `T000`) — should no longer return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)