### PR TITLE
feat: Add HTTP transport mode and health check endpoints for MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Optional HTTP transport mode for MCP using `StreamableHTTPServerTransport`.
+- New HTTP endpoints:
+  - `/mcp` for MCP requests (GET/POST/DELETE)
+  - `/healthz` for container and Kubernetes health probes
+
+### Changed
+- Docker defaults now use HTTP transport with `MCP_TRANSPORT=http` and `PORT=8080`.
+- Docker health check now probes `/healthz` instead of checking process state.
+- Docker image now exposes port `8080`.
+- Replaced `npm install -r` with `npm install` in Docker build.
+
 ## [1.1.0] - 2025-02-19
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY package.json ./
 
 # Install dependencies
-RUN npm install -r
+RUN npm install
 
 
 # Copy the rest of the application code
@@ -18,8 +18,14 @@ COPY . .
 # Build the TypeScript application
 RUN npm run build
 
-# Expose the port the app runs on
-EXPOSE 5173
+# Use HTTP transport by default for containers
+ENV MCP_TRANSPORT=http
+ENV PORT=8080
+
+# Expose the HTTP port
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD node -e "fetch('http://127.0.0.1:' + (process.env.PORT || 8080) + '/healthz').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 
 # Start the application
 CMD ["node", "./dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ To be fair, you usually dont usually "run" this server on it's own. It is suppos
 
 *   **Standalone Mode:**  This runs the server directly, and it will output messages to the terminal. The server will start and wait for client connections, so potentially rendering it useless except to see if it starts.
 *   **Development/Debug Mode:** This runs the server with the MCP Inspector. You can open the URL that it outputs in your browser and start playing around.
+*   **HTTP Mode (for Docker/Kubernetes):** This runs the MCP server over HTTP using the `/mcp` endpoint and exposes `/healthz` for probes.
 
 ### 3.1 Standalone Mode
 
@@ -128,6 +129,57 @@ This mode is useful for debugging.
     ```
     This will start the server and output a message like:  `🔍 MCP Inspector is up and running at http://localhost:5173 🚀`.
     This is the URL you'll use to open the MCP inspector in your Browser.
+
+### 3.3 HTTP Transport Mode (Streamable HTTP)
+
+This project now supports MCP over HTTP in addition to stdio.
+
+Set the following environment variables:
+
+```bash
+MCP_TRANSPORT=http
+PORT=8080
+```
+
+Then run:
+
+```bash
+npm run build
+npm run start
+```
+
+Available HTTP endpoints:
+
+*   `GET|POST|DELETE /mcp` - MCP transport endpoint.
+*   `GET /healthz` - Health endpoint for liveness/readiness checks.
+
+Example health check:
+
+```bash
+curl -i http://localhost:8080/healthz
+```
+
+### 3.4 Docker Run (HTTP + Healthcheck)
+
+The Docker image is configured to run in HTTP mode by default:
+
+*   `MCP_TRANSPORT=http`
+*   `PORT=8080`
+*   `EXPOSE 8080`
+*   Healthcheck probes `http://127.0.0.1:8080/healthz`
+
+Run the container with your existing `.env` file:
+
+```bash
+docker build -t mcp-abap-adt .
+docker run -d --name mcp-abap-adt --env-file .env -p 8080:8080 mcp-abap-adt
+```
+
+Check health status:
+
+```bash
+docker inspect --format='{{.State.Health.Status}}' mcp-abap-adt
+```
 
 ## 4. Integrating with Cline
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
   CallToolRequestSchema,
   ErrorCode,
@@ -9,6 +10,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import path from 'path';
 import dotenv from 'dotenv';
+import { createServer } from 'http';
 
 // Import handler functions
 import { handleGetProgram } from './handlers/handleGetProgram';
@@ -37,6 +39,13 @@ export interface SapConfig {
   username: string;
   password: string;
   client: string;
+}
+
+type TransportMode = 'stdio' | 'http';
+
+function getTransportMode(): TransportMode {
+  const mode = (process.env.MCP_TRANSPORT || process.env.TRANSPORT || 'stdio').toLowerCase();
+  return mode === 'http' || mode === 'streamable-http' ? 'http' : 'stdio';
 }
 
 /**
@@ -349,8 +358,63 @@ export class mcp_abap_adt_server {
    * Starts the MCP server and connects it to the transport.
    */
   async run() {
+    const mode = getTransportMode();
+
+    if (mode === 'http') {
+      await this.runHttp();
+      return;
+    }
+
+    await this.runStdio();
+  }
+
+  private async runStdio() {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
+  }
+
+  private async runHttp() {
+    const port = Number.parseInt(process.env.PORT || '8080', 10);
+
+    if (Number.isNaN(port) || port <= 0) {
+      throw new Error('PORT must be a valid positive integer when MCP_TRANSPORT=http');
+    }
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    await this.server.connect(transport);
+
+    const httpServer = createServer((req, res) => {
+      const pathname = req.url
+        ? new URL(req.url, `http://${req.headers.host || 'localhost'}`).pathname
+        : '/';
+
+      if (pathname === '/healthz') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok' }));
+        return;
+      }
+
+      if (pathname === '/mcp') {
+        transport.handleRequest(req, res).catch(() => {
+          if (!res.headersSent) {
+            res.writeHead(500, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Internal Server Error' }));
+          }
+        });
+        return;
+      }
+
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not Found' }));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      httpServer.once('error', reject);
+      httpServer.listen(port, () => resolve());
+    });
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
 import path from 'path';
 import dotenv from 'dotenv';
 import { createServer } from 'http';
+import { randomUUID } from 'crypto';
 
 // Import handler functions
 import { handleGetProgram } from './handlers/handleGetProgram';
@@ -381,7 +382,7 @@ export class mcp_abap_adt_server {
     }
 
     const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined,
+      sessionIdGenerator: () => randomUUID(),
     });
 
     await this.server.connect(transport);
@@ -398,7 +399,8 @@ export class mcp_abap_adt_server {
       }
 
       if (pathname === '/mcp') {
-        transport.handleRequest(req, res).catch(() => {
+        transport.handleRequest(req, res).catch((error) => {
+          console.error('Error handling /mcp request:', error);
           if (!res.headersSent) {
             res.writeHead(500, { 'content-type': 'application/json' });
             res.end(JSON.stringify({ error: 'Internal Server Error' }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
@@ -77,7 +77,7 @@ export function getConfig(): SapConfig {
  * Server class for interacting with ABAP systems via ADT.
  */
 export class mcp_abap_adt_server {
-  private server: Server;  // Instance of the MCP server
+  private server: McpServer;  // Instance of the MCP server
   private sapConfig: SapConfig; // SAP configuration
 
   /**
@@ -85,7 +85,11 @@ export class mcp_abap_adt_server {
    */
   constructor() {
     this.sapConfig = getConfig(); // Load SAP configuration
-    this.server = new Server(  // Initialize the MCP server
+    this.server = this.createServer();
+  }
+
+  private createServer(): McpServer {
+    const server = new McpServer(  // Initialize the MCP server
       {
         name: 'mcp-abap-adt', // Server name
         version: '0.1.0',       // Server version
@@ -98,18 +102,19 @@ export class mcp_abap_adt_server {
       }
     );
 
-    this.setupHandlers(); // Setup request handlers
+    this.setupHandlers(server); // Setup request handlers
+    return server;
   }
 
   /**
    * Sets up request handlers for listing and calling tools.
    * @private
    */
-  private setupHandlers() {
+  private setupHandlers(server: McpServer) {
     // Setup tool handlers
 
     // Handler for ListToolsRequest
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+    server.server.setRequestHandler(ListToolsRequestSchema, async () => {
       return {
         tools: [ // Define available tools
           {
@@ -313,7 +318,7 @@ export class mcp_abap_adt_server {
     });
 
     // Handler for CallToolRequest
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       switch (request.params.name) {
         case 'GetProgram':
           return await handleGetProgram(request.params.arguments);
@@ -349,11 +354,6 @@ export class mcp_abap_adt_server {
       }
     });
 
-    // Handle server shutdown on SIGINT (Ctrl+C)
-    process.on('SIGINT', async () => {
-      await this.server.close();
-      process.exit(0);
-    });
   }
 
   /**
@@ -371,6 +371,11 @@ export class mcp_abap_adt_server {
   }
 
   private async runStdio() {
+    process.on('SIGINT', async () => {
+      await this.server.close();
+      process.exit(0);
+    });
+
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
   }
@@ -382,17 +387,29 @@ export class mcp_abap_adt_server {
       throw new Error('PORT must be a valid positive integer when MCP_TRANSPORT=http');
     }
 
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
-    });
+    const sessions = new Map<string, { server: McpServer; transport: StreamableHTTPServerTransport }>();
 
-    await this.server.connect(transport);
+    process.on('SIGINT', async () => {
+      const uniqueServers = new Set<McpServer>();
+      for (const session of sessions.values()) {
+        uniqueServers.add(session.server);
+        await session.transport.close().catch(() => undefined);
+      }
+
+      for (const sessionServer of uniqueServers) {
+        await sessionServer.close().catch(() => undefined);
+      }
+
+      process.exit(0);
+    });
 
     const httpServer = createServer((req, res) => {
       const startedAt = Date.now();
       const method = req.method || 'UNKNOWN';
       const sessionIdHeader = req.headers['mcp-session-id'];
       const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
+      let requestServer: McpServer | undefined;
+      let requestSessionId: string | undefined = sessionId;
       const pathname = req.url
         ? new URL(req.url, `http://${req.headers.host || 'localhost'}`).pathname
         : '/';
@@ -406,7 +423,11 @@ export class mcp_abap_adt_server {
         }
 
         const level = res.statusCode >= 500 ? 'error' : res.statusCode >= 400 ? 'warning' : 'info';
-        this.server.sendLoggingMessage(
+        if (!requestServer) {
+          return;
+        }
+
+        requestServer.sendLoggingMessage(
           {
             level,
             logger: 'http',
@@ -417,7 +438,7 @@ export class mcp_abap_adt_server {
               durationMs,
             },
           },
-          sessionId,
+          requestSessionId,
         ).catch((error) => {
           console.error('Error sending MCP logging message:', error);
         });
@@ -430,7 +451,44 @@ export class mcp_abap_adt_server {
       }
 
       if (pathname === '/mcp') {
-        transport.handleRequest(req, res).catch((error) => {
+        const handleMcpRequest = async () => {
+          if (sessionId) {
+            const existingSession = sessions.get(sessionId);
+
+            if (!existingSession) {
+              res.writeHead(400, { 'content-type': 'application/json' });
+              res.end(JSON.stringify({ error: 'Bad Request: Invalid or expired MCP session ID' }));
+              return;
+            }
+
+            requestServer = existingSession.server;
+            await existingSession.transport.handleRequest(req, res);
+            return;
+          }
+
+          const sessionServer = this.createServer();
+          const sessionTransport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            onsessioninitialized: (newSessionId) => {
+              requestSessionId = newSessionId;
+              sessions.set(newSessionId, { server: sessionServer, transport: sessionTransport });
+            },
+          });
+
+          sessionTransport.onclose = () => {
+            const currentSessionId = sessionTransport.sessionId;
+            if (currentSessionId) {
+              sessions.delete(currentSessionId);
+            }
+            sessionServer.close().catch(() => undefined);
+          };
+
+          requestServer = sessionServer;
+          await sessionServer.connect(sessionTransport);
+          await sessionTransport.handleRequest(req, res);
+        };
+
+        handleMcpRequest().catch((error) => {
           console.error('Error handling /mcp request:', error);
           if (!res.headersSent) {
             res.writeHead(500, { 'content-type': 'application/json' });

--- a/src/index.ts
+++ b/src/index.ts
@@ -552,7 +552,17 @@ export class mcp_abap_adt_server {
 }
 
 // Create and run the server
-const server = new mcp_abap_adt_server();
-server.run().catch((error) => {
-  process.exit(1);
-});
+export async function startServer() {
+  const server = new mcp_abap_adt_server();
+  await server.run();
+}
+
+const isMainModule = process.argv[1]
+  ? require.main === module
+  : false;
+
+if (isMainModule) {
+  startServer().catch(() => {
+    process.exit(1);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,10 @@ function getTransportMode(): TransportMode {
   return mode === 'http' || mode === 'streamable-http' ? 'http' : 'stdio';
 }
 
+function isNotConnectedError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('Not connected');
+}
+
 /**
  * Retrieves SAP configuration from environment variables.
  *
@@ -326,20 +330,25 @@ export class mcp_abap_adt_server {
       const sessionId = extra.sessionId || normalizedSessionId;
 
       console.info(`[TOOL] Invoking ${toolName}`, toolArgs);
-      server.sendLoggingMessage(
-        {
-          level: 'info',
-          logger: 'tool',
-          data: {
-            event: 'tool_invocation',
-            toolName,
-            arguments: toolArgs,
+      if (server.isConnected()) {
+        server.sendLoggingMessage(
+          {
+            level: 'info',
+            logger: 'tool',
+            data: {
+              event: 'tool_invocation',
+              toolName,
+              arguments: toolArgs,
+            },
           },
-        },
-        sessionId,
-      ).catch((error) => {
-        console.error('Error sending tool invocation log:', error);
-      });
+          sessionId,
+        ).catch((error) => {
+          if (isNotConnectedError(error)) {
+            return;
+          }
+          console.error('Error sending tool invocation log:', error);
+        });
+      }
 
       switch (request.params.name) {
         case 'GetProgram':
@@ -410,6 +419,7 @@ export class mcp_abap_adt_server {
     }
 
     const sessions = new Map<string, { server: McpServer; transport: StreamableHTTPServerTransport }>();
+    const closingTransports = new WeakSet<StreamableHTTPServerTransport>();
 
     process.on('SIGINT', async () => {
       const uniqueServers = new Set<McpServer>();
@@ -445,7 +455,7 @@ export class mcp_abap_adt_server {
         }
 
         const level = res.statusCode >= 500 ? 'error' : res.statusCode >= 400 ? 'warning' : 'info';
-        if (!requestServer) {
+        if (!requestServer || !requestServer.isConnected()) {
           return;
         }
 
@@ -462,6 +472,9 @@ export class mcp_abap_adt_server {
           },
           requestSessionId,
         ).catch((error) => {
+          if (isNotConnectedError(error)) {
+            return;
+          }
           console.error('Error sending MCP logging message:', error);
         });
       });
@@ -498,11 +511,18 @@ export class mcp_abap_adt_server {
           });
 
           sessionTransport.onclose = () => {
+            if (closingTransports.has(sessionTransport)) {
+              return;
+            }
+
+            closingTransports.add(sessionTransport);
             const currentSessionId = sessionTransport.sessionId;
             if (currentSessionId) {
               sessions.delete(currentSessionId);
             }
-            sessionServer.close().catch(() => undefined);
+
+            // Avoid calling sessionServer.close() here: transport.close() triggers onclose,
+            // and calling close again can recurse through the same path.
           };
 
           requestServer = sessionServer;

--- a/src/index.ts
+++ b/src/index.ts
@@ -318,7 +318,29 @@ export class mcp_abap_adt_server {
     });
 
     // Handler for CallToolRequest
-    server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    server.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+      const toolName = request.params.name;
+      const toolArgs = request.params.arguments ?? {};
+      const headerSessionId = extra.requestInfo?.headers['mcp-session-id'];
+      const normalizedSessionId = Array.isArray(headerSessionId) ? headerSessionId[0] : headerSessionId;
+      const sessionId = extra.sessionId || normalizedSessionId;
+
+      console.info(`[TOOL] Invoking ${toolName}`, toolArgs);
+      server.sendLoggingMessage(
+        {
+          level: 'info',
+          logger: 'tool',
+          data: {
+            event: 'tool_invocation',
+            toolName,
+            arguments: toolArgs,
+          },
+        },
+        sessionId,
+      ).catch((error) => {
+        console.error('Error sending tool invocation log:', error);
+      });
+
       switch (request.params.name) {
         case 'GetProgram':
           return await handleGetProgram(request.params.arguments);

--- a/src/index.ts
+++ b/src/index.ts
@@ -501,10 +501,20 @@ export class mcp_abap_adt_server {
             return;
           }
 
+          // New sessions must start with POST. Rejecting early avoids creating
+          // orphaned transports on probes or malformed requests.
+          if (method !== 'POST') {
+            res.writeHead(400, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Bad Request: Initial MCP session request must use POST' }));
+            return;
+          }
+
           const sessionServer = this.createServer();
+          let sessionInitialized = false;
           const sessionTransport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
             onsessioninitialized: (newSessionId) => {
+              sessionInitialized = true;
               requestSessionId = newSessionId;
               sessions.set(newSessionId, { server: sessionServer, transport: sessionTransport });
             },
@@ -526,8 +536,17 @@ export class mcp_abap_adt_server {
           };
 
           requestServer = sessionServer;
-          await sessionServer.connect(sessionTransport);
-          await sessionTransport.handleRequest(req, res);
+          try {
+            await sessionServer.connect(sessionTransport);
+            await sessionTransport.handleRequest(req, res);
+          } finally {
+            // If initialization failed (for example, protocol validation errors),
+            // aggressively close transient resources to prevent request-path leaks.
+            if (!sessionInitialized) {
+              await sessionTransport.close().catch(() => undefined);
+              await sessionServer.close().catch(() => undefined);
+            }
+          }
         };
 
         handleMcpRequest().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,7 @@ export class mcp_abap_adt_server {
       {
         capabilities: {
           tools: {}, // Initially, no tools are registered
+          logging: {}, // Advertise MCP logging support
         },
       }
     );
@@ -388,9 +389,39 @@ export class mcp_abap_adt_server {
     await this.server.connect(transport);
 
     const httpServer = createServer((req, res) => {
+      const startedAt = Date.now();
+      const method = req.method || 'UNKNOWN';
+      const sessionIdHeader = req.headers['mcp-session-id'];
+      const sessionId = Array.isArray(sessionIdHeader) ? sessionIdHeader[0] : sessionIdHeader;
       const pathname = req.url
         ? new URL(req.url, `http://${req.headers.host || 'localhost'}`).pathname
         : '/';
+
+      res.on('finish', () => {
+        const durationMs = Date.now() - startedAt;
+        console.log(`[HTTP] ${method} ${pathname} -> ${res.statusCode} (${durationMs}ms)`);
+
+        if (pathname !== '/mcp') {
+          return;
+        }
+
+        const level = res.statusCode >= 500 ? 'error' : res.statusCode >= 400 ? 'warning' : 'info';
+        this.server.sendLoggingMessage(
+          {
+            level,
+            logger: 'http',
+            data: {
+              method,
+              path: pathname,
+              statusCode: res.statusCode,
+              durationMs,
+            },
+          },
+          sessionId,
+        ).catch((error) => {
+          console.error('Error sending MCP logging message:', error);
+        });
+      });
 
       if (pathname === '/healthz') {
         res.writeHead(200, { 'content-type': 'application/json' });


### PR DESCRIPTION
- Introduced optional HTTP transport mode using StreamableHTTPServerTransport.
- Added new HTTP endpoints: `/mcp` for MCP requests and `/healthz` for health checks.
- Updated Docker configuration to use HTTP transport by default and expose port 8080.
- Enhanced README with instructions for HTTP mode and Docker usage.