### PR TITLE
Add ABAP write/activate/delete tools

### DIFF
--- a/src/handlers/handleActivateObject.ts
+++ b/src/handlers/handleActivateObject.ts
@@ -1,0 +1,166 @@
+import { McpError, ErrorCode } from '../lib/utils';
+import { makeAdtRequest, getBaseUrl, return_error } from '../lib/utils';
+
+/**
+ * Map type/name to the ADT activation URI (the same one used in <adtcore:objectReference uri="...">).
+ * This is the OBJECT URI (without /source/main) — activation works at the object level.
+ */
+function activationUriFor(objectType: string, name: string): string {
+    const enc = encodeURIComponent(name);
+    const t = objectType.toUpperCase();
+    switch (t) {
+        case 'CLAS':
+        case 'CLAS/OC':
+        case 'CLASS':
+            return `/sap/bc/adt/oo/classes/${enc}`;
+        case 'INTF':
+        case 'INTF/OI':
+        case 'INTERFACE':
+            return `/sap/bc/adt/oo/interfaces/${enc}`;
+        case 'PROG':
+        case 'PROG/P':
+        case 'PROGRAM':
+        case 'REPORT':
+            return `/sap/bc/adt/programs/programs/${enc}`;
+        case 'PROG/I':
+        case 'INCLUDE':
+            return `/sap/bc/adt/programs/includes/${enc}`;
+        case 'FUGR':
+        case 'FUGR/F':
+        case 'FUNCTION_GROUP':
+            return `/sap/bc/adt/functions/groups/${enc}`;
+        case 'FUGR/FF':
+        case 'FUNCTION_MODULE': {
+            throw new McpError(ErrorCode.InvalidParams,
+                `For function modules, provide object_type='FUGR/FF', object_name='<FM>', and function_group='<FG>'. ` +
+                `Or pass object_uri directly.`);
+        }
+        case 'DDLS':
+        case 'DDLS/DF':
+            return `/sap/bc/adt/ddic/ddl/sources/${enc}`;
+        default:
+            throw new McpError(ErrorCode.InvalidParams,
+                `Unsupported objectType: ${objectType}. Supported: CLAS, INTF, PROG, PROG/I, FUGR, DDLS. ` +
+                `Or pass object_uri directly.`);
+    }
+}
+
+/**
+ * POST /sap/bc/adt/activation with an <adtcore:objectReferences> body.
+ *
+ * Args (either pattern works):
+ *   { object_type, object_name }   — convenient form for common types
+ *   { object_type:'FUGR/FF', object_name:<FM>, function_group:<FG> } — for FMs
+ *   { object_uri }                 — raw ADT URI (escape hatch for any type)
+ *
+ * Returns: activation messages. Empty messages = clean activation.
+ */
+export async function handleActivateObject(args: any) {
+    try {
+        let objectUri: string;
+        let objectName: string;
+
+        if (typeof args?.object_uri === 'string' && args.object_uri.length > 0) {
+            objectUri = args.object_uri;
+            objectName = args.object_name || objectUri.split('/').filter(Boolean).pop() || objectUri;
+        } else {
+            if (!args?.object_type || typeof args.object_type !== 'string') {
+                throw new McpError(ErrorCode.InvalidParams,
+                    'Either object_uri OR (object_type + object_name) is required.');
+            }
+            if (!args?.object_name || typeof args.object_name !== 'string') {
+                throw new McpError(ErrorCode.InvalidParams, 'object_name is required (string)');
+            }
+            const t = args.object_type.toUpperCase();
+            if (t === 'FUGR/FF' || t === 'FUNCTION_MODULE') {
+                if (!args?.function_group || typeof args.function_group !== 'string') {
+                    throw new McpError(ErrorCode.InvalidParams,
+                        'function_group is required when activating a function module.');
+                }
+                const encFm = encodeURIComponent(args.object_name);
+                const encFg = encodeURIComponent(args.function_group);
+                objectUri = `/sap/bc/adt/functions/groups/${encFg}/fmodules/${encFm}`;
+            } else {
+                objectUri = activationUriFor(args.object_type, args.object_name);
+            }
+            objectName = args.object_name;
+        }
+
+        const xmlBody =
+            `<?xml version="1.0" encoding="UTF-8"?>\n` +
+            `<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">\n` +
+            `  <adtcore:objectReference adtcore:uri="${objectUri.replace(/&/g, '&amp;').replace(/"/g, '&quot;')}" ` +
+            `adtcore:name="${String(objectName).replace(/&/g, '&amp;').replace(/"/g, '&quot;')}"/>\n` +
+            `</adtcore:objectReferences>`;
+
+        const url = `${await getBaseUrl()}/sap/bc/adt/activation?method=activate&preauditRequested=true`;
+
+        const response = await makeAdtRequest(url, 'POST', 60000, xmlBody, undefined, {
+            'Content-Type': 'application/xml',
+            'Accept': 'application/xml',
+        });
+
+        const body = typeof response.data === 'string' ? response.data : String(response.data);
+
+        // ADT returns 200 with either: empty body (clean), <chkl:messages> list with
+        // <msg type="E|W|I" line="N" .../> children, or <inactive>... refs. Parse them
+        // into structured messages so callers can iterate without regex.
+        type AdtMsg = { severity: string; line: string; offset: string; message: string };
+        const messages: AdtMsg[] = [];
+        const msgRe = /<msg\b([^>]*)>([\s\S]*?)<\/msg>/g;
+        const attr = (s: string, name: string) => {
+            const m = s.match(new RegExp(`${name}="([^"]*)"`, 'i'));
+            return m ? m[1] : '';
+        };
+        let m: RegExpExecArray | null;
+        while ((m = msgRe.exec(body)) !== null) {
+            const attrs = m[1];
+            const inner = m[2];
+            // shortText/txt or longText etc.
+            const txtMatch = inner.match(/<txt>([\s\S]*?)<\/txt>/);
+            const text = (txtMatch ? txtMatch[1] : inner).replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+            const sevRaw = attr(attrs, 'type') || attr(attrs, 'severity');
+            // SAP "type" uses E/W/I/A; map to a verbose severity for callers.
+            const severityMap: Record<string, string> = { E: 'ERROR', W: 'WARNING', I: 'INFO', A: 'ABORT' };
+            // The msg `line` attribute is the Nth message index (1-based), NOT the source line.
+            // The real source line + column live in the href fragment as `#start=L,C`.
+            const href = attr(attrs, 'href');
+            const startMatch = href.match(/#start=(\d+),(\d+)/);
+            const sourceLine = startMatch ? startMatch[1] : (attr(attrs, 'line') || '?');
+            const sourceCol = startMatch ? startMatch[2] : (attr(attrs, 'offset') || '?');
+            messages.push({
+                severity: severityMap[sevRaw.toUpperCase()] || sevRaw.toUpperCase() || 'UNKNOWN',
+                line: sourceLine,
+                offset: sourceCol,
+                message: text,
+            });
+        }
+
+        const hasError = messages.some(m => m.severity === 'ERROR' || m.severity === 'ABORT');
+        const hasInactive = /<inactive\b/i.test(body);
+        const clean = !hasError && !hasInactive;
+
+        // Build a compact, agent-friendly text body. Include parsed messages.
+        let text: string;
+        if (clean && messages.length === 0) {
+            text = `Activation succeeded for ${objectUri}. No errors or inactive objects reported.`;
+        } else if (clean) {
+            // Warnings/info only — activation succeeded but with notes
+            text = `Activation succeeded for ${objectUri} with ${messages.length} non-error message(s):\n` +
+                   messages.map(m => `  [${m.severity}] line=${m.line} offset=${m.offset}: ${m.message}`).join('\n');
+        } else if (messages.length > 0) {
+            text = `Activation FAILED for ${objectUri}. ${messages.length} message(s):\n` +
+                   messages.map(m => `  [${m.severity}] line=${m.line} offset=${m.offset}: ${m.message}`).join('\n');
+        } else {
+            // Has inactive list but no parsed messages
+            text = `Activation could not complete for ${objectUri}. Server response:\n\n${body.slice(0, 2000)}`;
+        }
+
+        return {
+            isError: !clean,
+            content: [{ type: 'text', text }],
+        };
+    } catch (error) {
+        return return_error(error);
+    }
+}

--- a/src/handlers/handleDeleteObject.ts
+++ b/src/handlers/handleDeleteObject.ts
@@ -1,0 +1,94 @@
+import { McpError, ErrorCode } from '../lib/utils';
+import { makeAdtRequest, getBaseUrl, return_error } from '../lib/utils';
+import { lockObject, unlockObject } from '../lib/adtEdit';
+
+/**
+ * Map an object type/name pair to its ADT base URI.
+ * Extend as needed for additional types.
+ */
+function resolveObjectBase(objectType: string, name: string, baseUrl: string): string {
+    const enc = encodeURIComponent(name);
+    const t = objectType.toUpperCase();
+    switch (t) {
+        case 'CLAS':
+        case 'CLAS/OC':
+        case 'CLASS':
+            return `${baseUrl}/sap/bc/adt/oo/classes/${enc}`;
+        case 'INTF':
+        case 'INTF/OI':
+        case 'INTERFACE':
+            return `${baseUrl}/sap/bc/adt/oo/interfaces/${enc}`;
+        case 'PROG':
+        case 'PROG/P':
+        case 'PROGRAM':
+        case 'REPORT':
+            return `${baseUrl}/sap/bc/adt/programs/programs/${enc}`;
+        case 'PROG/I':
+        case 'INCLUDE':
+            return `${baseUrl}/sap/bc/adt/programs/includes/${enc}`;
+        case 'FUGR':
+        case 'FUGR/F':
+        case 'FUNCTION_GROUP':
+            return `${baseUrl}/sap/bc/adt/functions/groups/${enc}`;
+        case 'DDLS':
+        case 'DDLS/DF':
+            return `${baseUrl}/sap/bc/adt/ddic/ddl/sources/${enc}`;
+        default:
+            throw new McpError(ErrorCode.InvalidParams,
+                `Unsupported objectType: ${objectType}. ` +
+                `Supported: CLAS, INTF, PROG (P/I), FUGR, DDLS.`);
+    }
+}
+
+/**
+ * Delete an ABAP repository object via ADT REST. Acquires a DELETE lock,
+ * issues HTTP DELETE, then releases (server typically auto-releases on success).
+ *
+ * Args:
+ *   object_type               — 'CLAS' | 'INTF' | 'PROG' | 'PROG/I' (include) | 'FUGR' | 'DDLS'
+ *                               (or fully qualified like 'CLAS/OC', 'PROG/P')
+ *   object_name               — e.g. 'ZCL_HELLO_SSO_TEST'
+ *   transport_request_number? — optional TR
+ *
+ * Note: this is destructive. The MCP framework should already gate this behind
+ * an explicit confirmation prompt to the user.
+ */
+export async function handleDeleteObject(args: any) {
+    try {
+        if (!args?.object_type || typeof args.object_type !== 'string') {
+            throw new McpError(ErrorCode.InvalidParams, 'object_type is required (string)');
+        }
+        if (!args?.object_name || typeof args.object_name !== 'string') {
+            throw new McpError(ErrorCode.InvalidParams, 'object_name is required (string)');
+        }
+
+        const baseUrl = String(await getBaseUrl());
+        const objectBase = resolveObjectBase(args.object_type, args.object_name, baseUrl);
+
+        // Acquire delete-lock (accessMode=MODIFY is what ADT actually uses for deletes too)
+        const lockHandle = await lockObject(objectBase);
+        try {
+            let deleteUrl = `${objectBase}?lockHandle=${encodeURIComponent(lockHandle)}`;
+            if (args.transport_request_number) {
+                deleteUrl += `&corrNr=${encodeURIComponent(args.transport_request_number)}`;
+            }
+            await makeAdtRequest(deleteUrl, 'DELETE', 60000, undefined, undefined, {
+                'X-sap-adt-sessiontype': 'stateful',
+            });
+        } catch (e) {
+            // Always try to unlock so we don't leave a stale ENQUEUE lock behind
+            await unlockObject(objectBase, lockHandle);
+            throw e;
+        }
+
+        return {
+            isError: false,
+            content: [{
+                type: 'text',
+                text: `${args.object_type} ${args.object_name} deleted successfully.`,
+            }],
+        };
+    } catch (error) {
+        return return_error(error);
+    }
+}

--- a/src/handlers/handleSetClass.ts
+++ b/src/handlers/handleSetClass.ts
@@ -1,0 +1,61 @@
+import { McpError, ErrorCode } from '../lib/utils';
+import { getBaseUrl, return_error } from '../lib/utils';
+import { withWriteAccess, putSource } from '../lib/adtEdit';
+
+const VALID_PARTS = ['main', 'definitions', 'implementations', 'macros', 'testclasses'] as const;
+type Part = typeof VALID_PARTS[number];
+
+/**
+ * Write the source of an ABAP class (CLAS/OC). A class has multiple "source parts"
+ * in ADT — by default we write `main` which is the full class body (definition +
+ * implementation as one source). The other parts (definitions / implementations /
+ * macros / testclasses) are separate when the class uses include splits.
+ *
+ * Args:
+ *   class_name                — name of the class (e.g. ZCL_HELLO_SSO_TEST)
+ *   source                    — full new source text
+ *   part?                     — optional, one of: main | definitions | implementations | macros | testclasses
+ *                               default: 'main'
+ *   transport_request_number? — optional TR for non-$TMP objects
+ */
+export async function handleSetClass(args: any) {
+    try {
+        if (!args?.class_name || typeof args.class_name !== 'string') {
+            throw new McpError(ErrorCode.InvalidParams, 'class_name is required (string)');
+        }
+        if (typeof args?.source !== 'string') {
+            throw new McpError(ErrorCode.InvalidParams, 'source is required (string)');
+        }
+        const part: Part = (args.part as Part) || 'main';
+        if (!VALID_PARTS.includes(part)) {
+            throw new McpError(ErrorCode.InvalidParams,
+                `part must be one of: ${VALID_PARTS.join(', ')}`);
+        }
+
+        const encoded = encodeURIComponent(args.class_name);
+        const objectBase = `${await getBaseUrl()}/sap/bc/adt/oo/classes/${encoded}`;
+        // main is the top-level source; other parts live under /includes/<part>/source/main
+        const sourceUri = part === 'main'
+            ? `${objectBase}/source/main`
+            : `${objectBase}/includes/${part}/source/main`;
+
+        await withWriteAccess(objectBase, (lockHandle) =>
+            putSource(sourceUri, lockHandle, args.source, {
+                transportRequestNumber: args.transport_request_number,
+            })
+        );
+
+        return {
+            isError: false,
+            content: [{
+                type: 'text',
+                text:
+                    `Class ${args.class_name} ${part} source updated successfully. ` +
+                    `Activate with mcp__sap-adt-official__abap_activate_objects ` +
+                    `(uri = '${sourceUri.substring(sourceUri.indexOf('/sap'))}').`,
+            }],
+        };
+    } catch (error) {
+        return return_error(error);
+    }
+}

--- a/src/handlers/handleSetFunction.ts
+++ b/src/handlers/handleSetFunction.ts
@@ -1,0 +1,54 @@
+import { McpError, ErrorCode } from '../lib/utils';
+import { getBaseUrl, return_error } from '../lib/utils';
+import { withWriteAccess, putSource } from '../lib/adtEdit';
+
+/**
+ * Write the source of a function module (FUGR/FF).
+ *
+ * Args:
+ *   function_name             — FM name (e.g. /SKYVVA/MULTI_ITAB_ADAPTER_V3)
+ *   function_group            — Function group (e.g. /SKYVVA/ADAPTERS_V2_3)
+ *   source                    — full new source text (between FUNCTION ... ENDFUNCTION)
+ *   transport_request_number? — optional TR
+ *
+ * Note: FMs lock at the function-module level, not the group level. The PUT URI
+ * is the FM main source. The group itself owns includes (top, main, ...), to write
+ * those use SetInclude with the include name (LZ<FG>TOP, L<FG>U01, etc.).
+ */
+export async function handleSetFunction(args: any) {
+    try {
+        if (!args?.function_name || typeof args.function_name !== 'string') {
+            throw new McpError(ErrorCode.InvalidParams, 'function_name is required (string)');
+        }
+        if (!args?.function_group || typeof args.function_group !== 'string') {
+            throw new McpError(ErrorCode.InvalidParams, 'function_group is required (string)');
+        }
+        if (typeof args?.source !== 'string') {
+            throw new McpError(ErrorCode.InvalidParams, 'source is required (string)');
+        }
+
+        const encFm = encodeURIComponent(args.function_name);
+        const encFg = encodeURIComponent(args.function_group);
+        const objectBase = `${await getBaseUrl()}/sap/bc/adt/functions/groups/${encFg}/fmodules/${encFm}`;
+        const sourceUri = `${objectBase}/source/main`;
+
+        await withWriteAccess(objectBase, (lockHandle) =>
+            putSource(sourceUri, lockHandle, args.source, {
+                transportRequestNumber: args.transport_request_number,
+            })
+        );
+
+        return {
+            isError: false,
+            content: [{
+                type: 'text',
+                text:
+                    `Function Module ${args.function_name} (group ${args.function_group}) ` +
+                    `source updated successfully. Activate with mcp__sap-adt-official__abap_activate_objects ` +
+                    `(uri = '/sap/bc/adt/functions/groups/${encFg}/fmodules/${encFm}/source/main').`,
+            }],
+        };
+    } catch (error) {
+        return return_error(error);
+    }
+}

--- a/src/handlers/handleSetInclude.ts
+++ b/src/handlers/handleSetInclude.ts
@@ -1,0 +1,47 @@
+import { McpError, ErrorCode } from '../lib/utils';
+import { getBaseUrl, return_error } from '../lib/utils';
+import { withWriteAccess, putSource } from '../lib/adtEdit';
+
+/**
+ * Write an ABAP include's (PROG/I) source main.
+ *
+ * Args:
+ *   include_name              — name of the include (e.g. "/SKYVVA/CL_FOO_BAR_DEFINITIONS")
+ *   source                    — full new source text
+ *   transport_request_number  — optional TR
+ *
+ * Returns: success line + activation hint.
+ */
+export async function handleSetInclude(args: any) {
+    try {
+        if (!args?.include_name || typeof args.include_name !== 'string') {
+            throw new McpError(ErrorCode.InvalidParams, 'include_name is required (string)');
+        }
+        if (typeof args?.source !== 'string') {
+            throw new McpError(ErrorCode.InvalidParams, 'source is required (string)');
+        }
+
+        const encoded = encodeURIComponent(args.include_name);
+        const objectBase = `${await getBaseUrl()}/sap/bc/adt/programs/includes/${encoded}`;
+        const sourceUri = `${objectBase}/source/main`;
+
+        await withWriteAccess(objectBase, (lockHandle) =>
+            putSource(sourceUri, lockHandle, args.source, {
+                transportRequestNumber: args.transport_request_number,
+            })
+        );
+
+        return {
+            isError: false,
+            content: [{
+                type: 'text',
+                text:
+                    `Include ${args.include_name} source updated successfully. ` +
+                    `Activate with mcp__sap-adt-official__abap_activate_objects (uri = ` +
+                    `'/sap/bc/adt/programs/includes/${encoded}/source/main') to compile.`,
+            }],
+        };
+    } catch (error) {
+        return return_error(error);
+    }
+}

--- a/src/handlers/handleSetProgram.ts
+++ b/src/handlers/handleSetProgram.ts
@@ -1,0 +1,49 @@
+import { McpError, ErrorCode } from '../lib/utils';
+import { getBaseUrl, return_error } from '../lib/utils';
+import { withWriteAccess, putSource } from '../lib/adtEdit';
+
+/**
+ * Write a classical ABAP report's (PROG/P) source main.
+ *
+ * Args:
+ *   program_name              — e.g. "/SKYVVA/TEST_INTERFACE" or "Z_ALV_TEST_01"
+ *   source                    — full new source text (UTF-8, line endings normalized to LF)
+ *   transport_request_number  — optional; only required for non-$TMP objects not yet
+ *                               recorded in any open TR for this user. If the object is
+ *                               already part of an open TR you have, omit this.
+ *
+ * Returns: brief success line. Use mcp__sap-adt-official__abap_activate_objects to compile.
+ */
+export async function handleSetProgram(args: any) {
+    try {
+        if (!args?.program_name || typeof args.program_name !== 'string') {
+            throw new McpError(ErrorCode.InvalidParams, 'program_name is required (string)');
+        }
+        if (typeof args?.source !== 'string') {
+            throw new McpError(ErrorCode.InvalidParams, 'source is required (string)');
+        }
+
+        const encoded = encodeURIComponent(args.program_name);
+        const objectBase = `${await getBaseUrl()}/sap/bc/adt/programs/programs/${encoded}`;
+        const sourceUri = `${objectBase}/source/main`;
+
+        await withWriteAccess(objectBase, (lockHandle) =>
+            putSource(sourceUri, lockHandle, args.source, {
+                transportRequestNumber: args.transport_request_number,
+            })
+        );
+
+        return {
+            isError: false,
+            content: [{
+                type: 'text',
+                text:
+                    `Program ${args.program_name} source updated successfully. ` +
+                    `Activate with mcp__sap-adt-official__abap_activate_objects (uri = ` +
+                    `'/sap/bc/adt/programs/programs/${encoded}/source/main') to compile.`,
+            }],
+        };
+    } catch (error) {
+        return return_error(error);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,12 @@ import { handleGetTypeInfo } from './handlers/handleGetTypeInfo';
 import { handleGetInterface } from './handlers/handleGetInterface';
 import { handleGetTransaction } from './handlers/handleGetTransaction';
 import { handleSearchObject } from './handlers/handleSearchObject';
+import { handleSetProgram } from './handlers/handleSetProgram';
+import { handleSetInclude } from './handlers/handleSetInclude';
+import { handleSetClass } from './handlers/handleSetClass';
+import { handleSetFunction } from './handlers/handleSetFunction';
+import { handleDeleteObject } from './handlers/handleDeleteObject';
+import { handleActivateObject } from './handlers/handleActivateObject';
 
 // Import shared utility functions and types
 import { getBaseUrl, getAuthHeaders, createAxiosInstance, makeAdtRequest, return_error, return_response } from './lib/utils';
@@ -296,6 +302,151 @@ export class mcp_abap_adt_server {
               },
               required: ['interface_name']
             }
+          },
+          {
+            name: 'SetProgram',
+            description: 'Overwrite the source code of an existing ABAP report/program (PROG/P). Uses ADT lock -> PUT source -> unlock. Use mcp__sap-adt-official__abap_activate_objects afterwards to compile.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                program_name: {
+                  type: 'string',
+                  description: 'Name of the ABAP program (e.g. /SKYVVA/TEST_INTERFACE or Z_ALV_TEST_01)'
+                },
+                source: {
+                  type: 'string',
+                  description: 'Full new source code to write (UTF-8, the entire object body)'
+                },
+                transport_request_number: {
+                  type: 'string',
+                  description: 'Optional. Only needed for non-$TMP objects not yet recorded in an open TR for this user.'
+                }
+              },
+              required: ['program_name', 'source']
+            }
+          },
+          {
+            name: 'SetInclude',
+            description: 'Overwrite the source code of an existing ABAP include (PROG/I). Uses ADT lock -> PUT source -> unlock. Activate afterwards via official MCP.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                include_name: {
+                  type: 'string',
+                  description: 'Name of the ABAP include'
+                },
+                source: {
+                  type: 'string',
+                  description: 'Full new source code to write'
+                },
+                transport_request_number: {
+                  type: 'string',
+                  description: 'Optional. Only needed for non-$TMP objects not yet recorded in an open TR for this user.'
+                }
+              },
+              required: ['include_name', 'source']
+            }
+          },
+          {
+            name: 'SetClass',
+            description: 'Overwrite the source of an ABAP class (CLAS/OC). By default writes the main source. For split classes, pass part = definitions | implementations | macros | testclasses. Activate via official MCP after.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                class_name: {
+                  type: 'string',
+                  description: 'Name of the ABAP class (e.g. ZCL_HELLO_SSO_TEST)'
+                },
+                source: {
+                  type: 'string',
+                  description: 'Full new source code to write'
+                },
+                part: {
+                  type: 'string',
+                  enum: ['main', 'definitions', 'implementations', 'macros', 'testclasses'],
+                  default: 'main',
+                  description: 'Which source part to write. Default: main (full class body).'
+                },
+                transport_request_number: {
+                  type: 'string',
+                  description: 'Optional. Only needed for non-$TMP objects not yet recorded in an open TR for this user.'
+                }
+              },
+              required: ['class_name', 'source']
+            }
+          },
+          {
+            name: 'SetFunction',
+            description: 'Overwrite the source of an ABAP function module (FUGR/FF). The new source is the body between FUNCTION ... ENDFUNCTION. Activate via official MCP after.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                function_name: {
+                  type: 'string',
+                  description: 'Name of the function module'
+                },
+                function_group: {
+                  type: 'string',
+                  description: 'Name of the function group containing this FM'
+                },
+                source: {
+                  type: 'string',
+                  description: 'Full new source code'
+                },
+                transport_request_number: {
+                  type: 'string',
+                  description: 'Optional. Only needed for non-$TMP objects not yet recorded in an open TR for this user.'
+                }
+              },
+              required: ['function_name', 'function_group', 'source']
+            }
+          },
+          {
+            name: 'ActivateObject',
+            description: 'Compile + activate an ABAP repository object (POST /sap/bc/adt/activation). Works for any object type — no IDE needed.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                object_type: {
+                  type: 'string',
+                  description: 'Object type: CLAS | INTF | PROG | PROG/I | FUGR | FUGR/FF (FM) | DDLS. Fully qualified codes (CLAS/OC etc.) also accepted. If omitted, supply object_uri instead.'
+                },
+                object_name: {
+                  type: 'string',
+                  description: 'Object name (e.g. /SKYVVA/TEST_INTERFACE).'
+                },
+                function_group: {
+                  type: 'string',
+                  description: 'REQUIRED when object_type is FUGR/FF (function module).'
+                },
+                object_uri: {
+                  type: 'string',
+                  description: 'Escape hatch: raw ADT URI (e.g. /sap/bc/adt/programs/programs/%2FSKYVVA%2FTEST_INTERFACE). Overrides object_type/name when present.'
+                }
+              }
+            }
+          },
+          {
+            name: 'DeleteObject',
+            description: 'Delete an ABAP repository object (class, interface, program, include, function group, CDS). DESTRUCTIVE — confirm with user before invoking.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                object_type: {
+                  type: 'string',
+                  description: 'Object type: CLAS | INTF | PROG | PROG/I (include) | FUGR | DDLS. Fully qualified (CLAS/OC etc.) also accepted.'
+                },
+                object_name: {
+                  type: 'string',
+                  description: 'Object name'
+                },
+                transport_request_number: {
+                  type: 'string',
+                  description: 'Optional. Only needed for non-$TMP objects not yet recorded in an open TR for this user.'
+                }
+              },
+              required: ['object_type', 'object_name']
+            }
           }
         ]
       };
@@ -330,6 +481,18 @@ export class mcp_abap_adt_server {
           return await handleGetInterface(request.params.arguments);
         case 'GetTransaction':
           return await handleGetTransaction(request.params.arguments);
+        case 'SetProgram':
+          return await handleSetProgram(request.params.arguments);
+        case 'SetInclude':
+          return await handleSetInclude(request.params.arguments);
+        case 'SetClass':
+          return await handleSetClass(request.params.arguments);
+        case 'SetFunction':
+          return await handleSetFunction(request.params.arguments);
+        case 'DeleteObject':
+          return await handleDeleteObject(request.params.arguments);
+        case 'ActivateObject':
+          return await handleActivateObject(request.params.arguments);
         default:
           throw new McpError(
             ErrorCode.MethodNotFound,

--- a/src/lib/adtEdit.ts
+++ b/src/lib/adtEdit.ts
@@ -1,0 +1,120 @@
+import { makeAdtRequest } from './utils';
+
+/**
+ * Edit-flow helpers for ABAP objects over ADT REST.
+ *
+ * Every ABAP object type uses the same lock/PUT/unlock sequence; only the URI changes.
+ * Centralising it here keeps each Set* handler ~10 lines.
+ *
+ * Sequence per write:
+ *   1. POST  {objectBase}?_action=LOCK&accessMode=MODIFY   (stateful)
+ *      -> XML body with <LOCK_HANDLE>...</LOCK_HANDLE>
+ *   2. PUT   {objectBase}/source/main?lockHandle=<h>       (stateful, body=new source)
+ *      (or another sub-URI like /includes/definitions for class parts)
+ *   3. POST  {objectBase}?_action=UNLOCK&lockHandle=<h>    (stateful)
+ *
+ * Notes:
+ *  - Activation is intentionally NOT done here: the user already has
+ *    mcp__sap-adt-official__abap_activate_objects, which is the authoritative
+ *    activator. Keeping the responsibilities separate also lets a caller batch
+ *    multiple Set* edits and activate once.
+ *  - Cookies (sap-contextid / JSESSIONID) are tracked globally in utils.ts so
+ *    the stateful session survives across the three calls.
+ *  - We always pass `Accept` for the lock so the server returns the lock
+ *    handle XML body even when other variants exist.
+ */
+
+const STATEFUL = 'X-sap-adt-sessiontype';
+const LOCK_ACCEPT = 'application/vnd.sap.as+xml;dataname=com.sap.adt.lock.Result2,application/vnd.sap.as+xml;dataname=com.sap.adt.lock.Result';
+
+/** Extract `<LOCK_HANDLE>...</LOCK_HANDLE>` from the ADT lock-response XML. */
+export function parseLockHandle(xml: string): string {
+    if (!xml || typeof xml !== 'string') {
+        throw new Error(`Cannot parse lock handle from non-string body: ${typeof xml}`);
+    }
+    const match = xml.match(/<LOCK_HANDLE>([^<]+)<\/LOCK_HANDLE>/i);
+    if (!match) {
+        throw new Error(`No LOCK_HANDLE in ADT lock response. First 500 chars: ${xml.substring(0, 500)}`);
+    }
+    return match[1];
+}
+
+/**
+ * POST {objectBase}?_action=LOCK&accessMode=MODIFY
+ *
+ * Returns the lock handle. The lock response BODY also contains a CORRNR field
+ * with the object's existing TR (if any). We do NOT pass corrNr here — ADT only
+ * accepts it for objects that need a fresh TR assignment, and for objects
+ * already in a TR it errors with "Parameter corrNr could not be found". If a
+ * transport_request_number was supplied, it's used on the PUT instead.
+ */
+export async function lockObject(objectBase: string): Promise<string> {
+    const url = `${objectBase}?_action=LOCK&accessMode=MODIFY`;
+    const response = await makeAdtRequest(url, 'POST', 30000, undefined, undefined, {
+        [STATEFUL]: 'stateful',
+        'Accept': LOCK_ACCEPT,
+    });
+    return parseLockHandle(typeof response.data === 'string' ? response.data : String(response.data));
+}
+
+/** POST {objectBase}?_action=UNLOCK&lockHandle=<h>. Errors are warned, not thrown. */
+export async function unlockObject(objectBase: string, lockHandle: string): Promise<void> {
+    const url = `${objectBase}?_action=UNLOCK&lockHandle=${encodeURIComponent(lockHandle)}`;
+    try {
+        await makeAdtRequest(url, 'POST', 30000, undefined, undefined, {
+            [STATEFUL]: 'stateful',
+        });
+    } catch (e) {
+        // Don't mask a successful write because the unlock fizzled — lock will time out
+        // server-side anyway, and re-locking the same user on the same object is harmless.
+        // eslint-disable-next-line no-console
+        console.error(`[adtEdit] unlock failed for ${objectBase}: ${e instanceof Error ? e.message : e}`);
+    }
+}
+
+/**
+ * lock -> fn(lockHandle) -> unlock (always, even on error).
+ * Use this in every Set* handler so the cleanup path is identical.
+ *
+ * NOTE: opts.transportRequestNumber is accepted here but is forwarded to the
+ * caller's `fn` via a closure, not to LOCK (see lockObject for why). The standard
+ * pattern is for the caller to pass it through to putSource() below.
+ */
+export async function withWriteAccess<T>(
+    objectBase: string,
+    fn: (lockHandle: string) => Promise<T>,
+    _opts: { transportRequestNumber?: string } = {}
+): Promise<T> {
+    const lockHandle = await lockObject(objectBase);
+    try {
+        return await fn(lockHandle);
+    } finally {
+        await unlockObject(objectBase, lockHandle);
+    }
+}
+
+/**
+ * PUT {sourceUri}?lockHandle=<h>[&corrNr=<TR>] with raw ABAP source text.
+ * Caller has already acquired the lock via withWriteAccess.
+ *
+ * For objects already recorded in an open TR (the common case for non-$TMP
+ * objects you're editing routinely), corrNr is unnecessary and the server
+ * auto-uses the existing TR. For first-time edits of an object you need to
+ * supply corrNr — the server returns 400 if the object would need to be
+ * recorded but corrNr is missing.
+ */
+export async function putSource(
+    sourceUri: string,
+    lockHandle: string,
+    source: string,
+    opts: { transportRequestNumber?: string } = {}
+): Promise<void> {
+    let url = `${sourceUri}?lockHandle=${encodeURIComponent(lockHandle)}`;
+    if (opts.transportRequestNumber) {
+        url += `&corrNr=${encodeURIComponent(opts.transportRequestNumber)}`;
+    }
+    await makeAdtRequest(url, 'PUT', 60000, source, undefined, {
+        [STATEFUL]: 'stateful',
+        'Content-Type': 'text/plain; charset=utf-8',
+    });
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -51,12 +51,37 @@ export function cleanup() {
     axiosInstance = null;
     config = undefined;
     csrfToken = null;
-    cookies = null;
+    cookieJar.clear();
 }
 
 let config: SapConfig | undefined;
 let csrfToken: string | null = null;
-let cookies: string | null = null; // Variable to store cookies
+// Cookies stored as name -> value map so subsequent Set-Cookie responses MERGE rather than REPLACE.
+// A REPLACE loses JSESSIONID when a later response only sets sap-contextid, which breaks the
+// stateful LOCK -> PUT -> UNLOCK chain with "Session not found".
+const cookieJar: Map<string, string> = new Map();
+
+function cookieHeader(): string | null {
+    if (cookieJar.size === 0) return null;
+    return Array.from(cookieJar.entries()).map(([k, v]) => `${k}=${v}`).join('; ');
+}
+
+function absorbSetCookie(setCookieHeaders: string[] | string | undefined): void {
+    if (!setCookieHeaders) return;
+    const arr = Array.isArray(setCookieHeaders) ? setCookieHeaders : [setCookieHeaders];
+    for (const raw of arr) {
+        if (!raw) continue;
+        // each header is "name=value; Path=/; HttpOnly; ..." — we only care about name=value
+        const semi = raw.indexOf(';');
+        const nv = semi >= 0 ? raw.substring(0, semi) : raw;
+        const eq = nv.indexOf('=');
+        if (eq <= 0) continue;
+        const name = nv.substring(0, eq).trim();
+        const value = nv.substring(eq + 1).trim();
+        if (!name) continue;
+        cookieJar.set(name, value);
+    }
+}
 
 export async function getBaseUrl() {
     if (!config) {
@@ -102,9 +127,7 @@ async function fetchCsrfToken(url: string): Promise<string> {
         }
 
         // Extract and store cookies
-        if (response.headers['set-cookie']) {
-            cookies = response.headers['set-cookie'].join('; ');
-        }
+        absorbSetCookie(response.headers['set-cookie']);
 
         return token;
     } catch (error) {
@@ -113,9 +136,7 @@ async function fetchCsrfToken(url: string): Promise<string> {
             const token = error.response.headers['x-csrf-token'];
             if (token) {
                  // Extract and store cookies from the error response as well
-                if (error.response.headers['set-cookie']) {
-                    cookies = error.response.headers['set-cookie'].join('; ');
-                }
+                absorbSetCookie(error.response.headers['set-cookie']);
                 return token;
             }
         }
@@ -124,28 +145,31 @@ async function fetchCsrfToken(url: string): Promise<string> {
     }
 }
 
-export async function makeAdtRequest(url: string, method: string, timeout: number, data?: any, params?: any) {
-    // For POST/PUT requests, ensure we have a CSRF token
-    if ((method === 'POST' || method === 'PUT') && !csrfToken) {
+export async function makeAdtRequest(url: string, method: string, timeout: number, data?: any, params?: any, headers?: any) {
+    const isWriteMethod = method === 'POST' || method === 'PUT' || method === 'DELETE';
+    // For all write methods, ensure we have a CSRF token
+    if (isWriteMethod && !csrfToken) {
         try {
             csrfToken = await fetchCsrfToken(url);
         } catch (error) {
-            throw new Error('CSRF token is required for POST/PUT requests but could not be fetched');
+            throw new Error('CSRF token is required for write methods (POST/PUT/DELETE) but could not be fetched');
         }
     }
 
-    const requestHeaders = {
-        ...(await getAuthHeaders())
+    const requestHeaders: Record<string, string> = {
+        ...(await getAuthHeaders()),
+        ...(headers || {}) // caller-supplied headers (e.g. Accept, Content-Type)
     };
 
-    // Add CSRF token for POST/PUT requests
-    if ((method === 'POST' || method === 'PUT') && csrfToken) {
+    // Add CSRF token for all write methods
+    if (isWriteMethod && csrfToken) {
         requestHeaders['x-csrf-token'] = csrfToken;
     }
 
     // Add cookies if available
-    if (cookies) {
-        requestHeaders['Cookie'] = cookies;
+    const cookieStr = cookieHeader();
+    if (cookieStr) {
+        requestHeaders['Cookie'] = cookieStr;
     }
 
     const config: any = {
@@ -163,6 +187,10 @@ export async function makeAdtRequest(url: string, method: string, timeout: numbe
 
     try {
         const response = await createAxiosInstance()(config);
+        // Keep cookies in sync across stateful write flows (LOCK -> PUT -> UNLOCK).
+        // Without this, the sap-contextid / JSESSIONID set by the LOCK response is lost
+        // and the subsequent PUT fails with "lock handle not found".
+        absorbSetCookie(response.headers['set-cookie']);
         return response;
     } catch (error) {
         // If we get a 403 with "CSRF token validation failed", try to fetch a new token and retry
@@ -170,8 +198,19 @@ export async function makeAdtRequest(url: string, method: string, timeout: numbe
             error.response.data?.includes('CSRF')) {
             csrfToken = await fetchCsrfToken(url);
             config.headers['x-csrf-token'] = csrfToken;
-            return await createAxiosInstance()(config);
+            const retry = await createAxiosInstance()(config);
+            absorbSetCookie(retry.headers['set-cookie']);
+            return retry;
         }
         throw error;
     }
+}
+
+/**
+ * Drop stateful session state. Call between unrelated write transactions
+ * to force a fresh session and discard any stale lock handles.
+ */
+export function resetSession() {
+    csrfToken = null;
+    cookieJar.clear();
 }


### PR DESCRIPTION
## Summary

Closes the read-only gap. Adds six new MCP tools so an AI coding agent (or any MCP client) can drive the full ABAP development loop **read → change → compile → fix → re-compile → done** without an IDE in the picture.

| New tool | What it does |
|---|---|
| `SetProgram` | Overwrite source of an existing classical report (PROG/P) |
| `SetInclude` | Overwrite source of an existing include (PROG/I) |
| `SetClass` | Overwrite a class (CLAS/OC); optional `part` selects `main` / `definitions` / `implementations` / `macros` / `testclasses` |
| `SetFunction` | Overwrite source of a function module (FUGR/FF), takes `function_group` |
| `ActivateObject` | `POST /sap/bc/adt/activation`, parses `<chkl:messages>` into a structured `{ severity, line, offset, message }` list. `line`/`offset` come from the `href#start=L,C` fragment — so they're the **actual source position**, not the Nth-error counter |
| `DeleteObject` | `DELETE` any of: CLAS, INTF, PROG, PROG/I, FUGR, DDLS |

## Why

The current MCP only has `Get*` tools, which means an agent can read ABAP but can't write back, can't activate, can't tidy up. With these six tools added, a Claude / Copilot / etc. session can run a real edit-compile-fix loop in chat:

```
"Edit /XX/MY_REPORT to do Y.
 If activation fails, read the error list, fix line by line, and re-activate.
 Stop when ActivateObject returns isError: false."
```

Captured run from a verification session on the new tools:

```
CYCLE 1  - inject WRIITE typo + IF sy-subrc === 0
  SetProgram: ok
  ActivateObject: FAILED - 2 errors:
    [ERROR] line=24 offset=2 : The statement "WRIITE" is not expected.
                               A correct similar statement is "WRITE".
    [ERROR] line=52 offset=14: Relational operator "===" is not supported.

CYCLE 2  - fix typo only
  ActivateObject: FAILED - 1 error:
    [ERROR] line=52 offset=14: Relational operator "===" is not supported.

CYCLE 3  - fix operator
  ActivateObject: CLEAN  ✓
```

## Supporting changes

- **`src/lib/adtEdit.ts`** (new) — shared `lock → PUT → unlock` helper (`withWriteAccess`) + `putSource()`. Each `Set*` handler is ~10 lines.
- **`src/lib/utils.ts`** — cookie jar upgraded from REPLACE to MERGE-by-name. Without this, the stateful LOCK session's `sap-contextid` cookie overwrites the original `JSESSIONID` and the subsequent PUT fails with "Session not found". Also: DELETE now sends the CSRF token like POST/PUT.
- **`src/index.ts`** — register the six new tools.

## Transport handling note

For non-`$TMP` objects already recorded in an open TR, no `corrNr` is needed; the server picks up the existing TR. For first-time edits of objects not yet in a TR, pass `transport_request_number` on the `Set*` call (forwarded to the PUT, **not** the LOCK — the LOCK rejects `corrNr` on objects already in a TR with "Parameter corrNr could not be found").

## Validated on

NW 7.50, ABAP 7.50, macOS client.

- `SetProgram` round-trip on a `$TMP` report (write, verify, restore)
- Edit → `ActivateObject` → read-back on a non-`$TMP` namespace report
- The 3-cycle compile-error loop above
- `DeleteObject` removed a throwaway `$TMP` class

## Server-side requirements

None new. These tools use the standard ADT REST endpoints under `/sap/bc/adt/*` that NW 7.40+ ships active by default; the SICF activation that the existing `Get*` tools require is the same activation these tools need. No ABAP server-side install.

## Test plan
- [ ] Reviewer can install locally, hit any `$TMP` report with `SetProgram`, `GetProgram`, `ActivateObject`
- [ ] Reviewer can verify the compile-error loop on a deliberately-broken `$TMP` report
- [ ] Reviewer can `DeleteObject` a `$TMP` class created via the official SAP ADT MCP `abap_creation-create_object`

🤖 Generated with [Claude Code](https://claude.com/claude-code)